### PR TITLE
Add cell_size to resnet architecture

### DIFF
--- a/deepblink/networks/resnet.py
+++ b/deepblink/networks/resnet.py
@@ -4,27 +4,48 @@ import tensorflow as tf
 
 from ._networks import conv_block
 from ._networks import residual_block
+from ._networks import upconv_block
 
 
-def resnet(dropout: float = 0.2) -> tf.keras.models.Model:
+def resnet(dropout: float = 0.2, cell_size: int = 4) -> tf.keras.models.Model:
     """Residual network with interspersed dropout."""
     i = 6  # 64
 
-    inputs = tf.keras.layers.Input(shape=(512, 512, 1))
+    inputs = tf.keras.layers.Input(shape=(None, None, 1))
+    layers = []
 
-    # Down: 512 -> 256
+    # Down: halving
     x = conv_block(inputs=inputs, filters=2 ** (i), n_convs=3, dropout=dropout)
     x = residual_block(inputs=x, filters=2 ** (i))
     x = conv_block(inputs=x, filters=2 ** (i + 1), n_convs=3, dropout=dropout)
     x = tf.keras.layers.Dropout(dropout)(x)
+    layers.append(x)
     x = tf.keras.layers.MaxPool2D(pool_size=(2, 2))(x)
 
-    # Down: 256 -> 128
+    # Down: halving
     x = conv_block(inputs=x, filters=2 ** (i + 1), n_convs=3, dropout=dropout)
     x = residual_block(inputs=x, filters=2 ** (i + 1))
     x = conv_block(inputs=x, filters=2 ** (i + 1), n_convs=3, dropout=dropout)
     x = tf.keras.layers.Dropout(dropout)(x)
+    layers.append(x)
     x = tf.keras.layers.MaxPool2D(pool_size=(2, 2))(x)
+
+    # Dynamic down sampling
+    for n in range(cell_size // 4 - 1):
+        x = conv_block(inputs=x, filters=2 ** (i + 1 + n), n_convs=3, dropout=dropout)
+        x = residual_block(inputs=x, filters=2 ** (i + 1 + n))
+        x = conv_block(inputs=x, filters=2 ** (i + 1 + n), n_convs=3, dropout=dropout)
+        x = tf.keras.layers.Dropout(dropout)(x)
+        layers.append(x)
+        x = tf.keras.layers.MaxPool2D(pool_size=(2, 2))(x)
+
+    # Dynamic upsampling:
+    for n in range(int(2 // cell_size)):
+        x = conv_block(inputs=x, filters=2 ** (i + 1 - n), n_convs=3, dropout=dropout)
+        x = residual_block(inputs=x, filters=2 ** (i + 1 - n))
+        x = conv_block(inputs=x, filters=2 ** (i + 1 - n), n_convs=3, dropout=dropout)
+        x = tf.keras.layers.Dropout(dropout)(x)
+        x = upconv_block(inputs=x, skip=layers[-(n + 1)], filters=2 ** (i + 1), n_convs=1)
 
     # Connected
     x = conv_block(inputs=x, filters=2 ** (i + 2), n_convs=3, dropout=dropout)

--- a/deepblink/networks/resnet.py
+++ b/deepblink/networks/resnet.py
@@ -1,5 +1,7 @@
 """Residual network architecture."""
 
+import math
+
 import tensorflow as tf
 
 from ._networks import conv_block
@@ -11,15 +13,18 @@ def resnet(dropout: float = 0.2, cell_size: int = 4) -> tf.keras.models.Model:
     """Residual network with interspersed dropout."""
     i = 6  # 64
 
+    if not math.log(cell_size, 2).is_integer():
+        raise ValueError(f"cell_size must be a power of 2, but was given {cell_size}")
+
     inputs = tf.keras.layers.Input(shape=(None, None, 1))
-    layers = []
+    skip_layers = []
 
     # Down: halving
     x = conv_block(inputs=inputs, filters=2 ** (i), n_convs=3, dropout=dropout)
     x = residual_block(inputs=x, filters=2 ** (i))
     x = conv_block(inputs=x, filters=2 ** (i + 1), n_convs=3, dropout=dropout)
     x = tf.keras.layers.Dropout(dropout)(x)
-    layers.append(x)
+    skip_layers.append(x)
     x = tf.keras.layers.MaxPool2D(pool_size=(2, 2))(x)
 
     # Down: halving
@@ -27,25 +32,31 @@ def resnet(dropout: float = 0.2, cell_size: int = 4) -> tf.keras.models.Model:
     x = residual_block(inputs=x, filters=2 ** (i + 1))
     x = conv_block(inputs=x, filters=2 ** (i + 1), n_convs=3, dropout=dropout)
     x = tf.keras.layers.Dropout(dropout)(x)
-    layers.append(x)
+    skip_layers.append(x)
     x = tf.keras.layers.MaxPool2D(pool_size=(2, 2))(x)
 
-    # Dynamic down sampling
-    for n in range(cell_size // 4 - 1):
+    # Dynamic down sampling; if cell_size is higher than 4, to get the correct network output shape,
+    # we need to further down-sample by math.log(cell_size, 2) - 2 times.
+    # The -2 corresponds to the 2 halvings already done
+    ndown = max(0, math.log(cell_size, 2) - 2)
+    for n in range(int(ndown)):
         x = conv_block(inputs=x, filters=2 ** (i + 1 + n), n_convs=3, dropout=dropout)
         x = residual_block(inputs=x, filters=2 ** (i + 1 + n))
         x = conv_block(inputs=x, filters=2 ** (i + 1 + n), n_convs=3, dropout=dropout)
         x = tf.keras.layers.Dropout(dropout)(x)
-        layers.append(x)
+        skip_layers.append(x)
         x = tf.keras.layers.MaxPool2D(pool_size=(2, 2))(x)
 
-    # Dynamic upsampling:
+    # Dynamic upsampling: if cell_size is smaller than 4, after the 2 halvings,
+    # we need to upsample int(2 // cell_size) times
+    # If cell_size is 1, we need to upsample 2 == int(2 // cell_size)
+    # If cell_size is 2, we need to upsample 1 == int(2 // 2)
     for n in range(int(2 // cell_size)):
         x = conv_block(inputs=x, filters=2 ** (i + 1 - n), n_convs=3, dropout=dropout)
         x = residual_block(inputs=x, filters=2 ** (i + 1 - n))
         x = conv_block(inputs=x, filters=2 ** (i + 1 - n), n_convs=3, dropout=dropout)
         x = tf.keras.layers.Dropout(dropout)(x)
-        x = upconv_block(inputs=x, skip=layers[-(n + 1)], filters=2 ** (i + 1), n_convs=1)
+        x = upconv_block(inputs=x, skip=skip_layers[-(n + 1)], filters=2 ** (i + 1), n_convs=1)
 
     # Connected
     x = conv_block(inputs=x, filters=2 ** (i + 2), n_convs=3, dropout=dropout)

--- a/deepblink/training.py
+++ b/deepblink/training.py
@@ -179,6 +179,8 @@ def run_experiment(cfg: Dict, save_weights: bool = False):
     dataset_args = cfg.get("dataset_args", {})
     train_args = cfg.get("train_args", {})
 
+    network_args["cell_size"] = dataset_args["cell_size"]
+
     dataset = dataset_class(dataset_args["version"], dataset_args["cell_size"])
     dataset.load_data()
 


### PR DESCRIPTION
## Proposed changes

Resnet architecture was previously hard-coded on cell_size. Now Resnet architecture dynamically adapts to the cell_size from parameter file. This should (in a small range of cell sizes) solve the fourth and final "network" titled issue from #59.

**Note**: L2 norms are calculated based on the cell size. While the code works, networks with different cell sizes aren't directly comparable.

## Types of changes

 - [ ] Bugfix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation content update
 - [ ] Other (please describe):

## Checklist

Put an x in the boxes that apply. You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code so nothing breaks.

 - [x] I have read the [contributing guidelines](https://deepblink.readthedocs.io/en/latest/contributing.html)
 - [x] Lint and unit tests pass locally with my changes (`tox`)
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] I have added necessary documentation (if appropriate)
 - [ ] Any dependent changes have been merged and published in downstream modules
 - [ ] My commit messages format follow the project [git commit message format](https://github.com/slashsbin/styleguide-git-commit-message#commit-message-format)
 - [ ] First time only - I have added myself / the copyright holder to the authors.rst file

💔 Thank you!
