### PR TITLE
Fix losses output shapes

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,8 +9,8 @@ import tensorflow as tf
 
 from deepblink.cli import _grab_files
 from deepblink.cli import _predict
-from deepblink.losses import combined_f1_rmse
 from deepblink.losses import combined_bce_rmse
+from deepblink.losses import combined_f1_rmse
 from deepblink.losses import f1_score
 from deepblink.losses import rmse
 

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -70,7 +70,7 @@ def test_f1_loss(tensor_true, tensor_pred):
 def test_rmse():
     true_rmse = tf.constant([[[1, 0, 0], [1, 0.5, 0]], [[0, 0, 0], [1, 0.5, 0.5]]])
     pred_rmse = tf.constant([[[1, 0, 0], [1, 0.5, 0]], [[1, 0.5, 0.5], [0, 0.5, 0.5]]])
-    assert rmse(true_rmse, pred_rmse) == tf.constant(0, dtype=tf.float32)
+    assert rmse(true_rmse[..., 1:], pred_rmse[..., 1:]) == tf.constant(0, dtype=tf.float32)
 
 
 def test_combined_f1_rmse(tensor_true, tensor_pred):


### PR DESCRIPTION
## Proposed changes

tf.keras.losses.binary_crossentropy and categorical_crossentropy reduce last dimension of inputs by taking the average over the last dimension. This creates sometimes problem with manipulation of the dimensions (sum, mean over different axis). Here, we solved this issue by artificially expanding the inputs so that tf.keras.losses reduce over this newly created last axis.

 
## Types of changes

 - [x] Bugfix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation content update
 - [ ] Other (please describe):

## Checklist

Put an x in the boxes that apply. You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code so nothing breaks.

 - [x] I have read the [contributing guidelines](https://deepblink.readthedocs.io/en/latest/contributing.html)
 - [x] Lint and unit tests pass locally with my changes (`tox`)
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] I have added necessary documentation (if appropriate)
 - [ ] Any dependent changes have been merged and published in downstream modules
 - [ ] My commit messages format follow the project [git commit message format](https://github.com/slashsbin/styleguide-git-commit-message#commit-message-format)
 - [ ] First time only - I have added myself / the copyright holder to the authors.rst file

💔 Thank you!
