### PR TITLE
Cli redesign to contain submodules

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -52,6 +52,9 @@ method-rgx=[a-z_][a-z0-9_]{2,70}$
 # Maximum number of characters on a single line.
 max-line-length = 120
 
+# Allow f-strings in logging messages.
+logging-format-style=fstr
+
 [DESIGN]
 # Minimum number of public methods for a class (see R0903).
 min-public-methods = 0

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,27 +1,28 @@
 [MESSAGES CONTROL]
 
 # Disable the message(s) with the given id(s).
-# C0413 - wrong-import-position of third-party libraries
+# C0413 - wrong-import-position of third-party libraries.
+# E0203 - used when an instance member is accessed before it’s actually assigned.
 # E0401 - used when pylint has been unable to import a module.
 # E1130 - invalid-unary-operand-type false positive https://github.com/PyCQA/pylint/issues/1472
-# E1136 - emitted when a subscripted value doesn’t support subscription(i.e. doesn’t define __getitem__ method)
-# E0203 - used when an instance member is accessed before it’s actually assigned.
-# R0801 - similar lines across files
+# E1136 - emitted when a subscripted value doesn’t support subscription(i.e. doesn’t define __getitem__ method).
+# R0801 - similar lines across files.
 # W0102 - used when a mutable value as list or dictionary is detected in a default value for an argument.
 # W0201 - used when an instance attribute is defined outside the __init__ method.
-# W0235 - Useless super delegation in method '__init__'
-# W0511 - TODO comments
-# W1202 - logging-format-interpolation - Behavior barring fstrings in logging https://github.com/PyCQA/pylint/issues/2395
+# W0212 - access to protected member that is inevitable when breaking up argparse subparsers.
+# W0235 - useless super delegation in method '__init__'.
+# W0511 - TODO comments.
+# W1202 - logging-format-interpolation - Behavior barring fstrings in logging https://github.com/PyCQA/pylint/issues/2395.
 # bad-continuation: disagrees with black formatter
 # missing-function-dosctring: docstyle handles
-disable=E1136,E0401,W0201,W0235,W0511,bad-continuation
+disable = E0401, E1136, W0201, W0212, W0235, W0511, bad-continuation
 
 [MASTER]
 
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=numpy
+extension-pkg-whitelist = numpy
 
 [TYPECHECK]
 
@@ -29,12 +30,12 @@ extension-pkg-whitelist=numpy
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=numpy,skimage,tensorflow
+ignored-modules = numpy, skimage, tensorflow
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work
 # with qualified names.
-ignored-classes=numpy,skimage,tensorflow
+ignored-classes = numpy, skimage, tensorflow
 
 [BASIC]
 
@@ -42,10 +43,10 @@ ignored-classes=numpy,skimage,tensorflow
 good-names = _, a, b, c, d, e, f, i, j, k, n, N, m, M, D, p, r, t, v, x, X, y, Y, w, h, W, H, x1, x2, y1, y2, ax, df, xy, xyz, x0, y0, z0, z, xx, yy, app, log, tp, fp, fn
 
 # Regular expression which should only match correct function names
-function-rgx=[a-z_][a-z0-9_]{2,70}$
+function-rgx = [a-z_][a-z0-9_]{2,70}$
 
 # Regular expression which should only match correct method names
-method-rgx=[a-z_][a-z0-9_]{2,70}$
+method-rgx = [a-z_][a-z0-9_]{2,70}$
 
 [FORMAT]
 
@@ -53,7 +54,7 @@ method-rgx=[a-z_][a-z0-9_]{2,70}$
 max-line-length = 120
 
 # Allow f-strings in logging messages.
-logging-format-style=fstr
+logging-format-style = new
 
 [DESIGN]
 # Minimum number of public methods for a class (see R0903).
@@ -61,7 +62,5 @@ min-public-methods = 0
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes = 15
-
 max-locals = 25
-
 max-args = 10

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,18 +1,11 @@
 [MESSAGES CONTROL]
 
 # Disable the message(s) with the given id(s).
-# C0413 - wrong-import-position of third-party libraries.
-# E0203 - used when an instance member is accessed before it’s actually assigned.
 # E0401 - used when pylint has been unable to import a module.
-# E1130 - invalid-unary-operand-type false positive https://github.com/PyCQA/pylint/issues/1472
-# E1136 - emitted when a subscripted value doesn’t support subscription(i.e. doesn’t define __getitem__ method).
-# R0801 - similar lines across files.
-# W0102 - used when a mutable value as list or dictionary is detected in a default value for an argument.
 # W0201 - used when an instance attribute is defined outside the __init__ method.
 # W0212 - access to protected member that is inevitable when breaking up argparse subparsers.
 # W0235 - useless super delegation in method '__init__'.
 # W0511 - TODO comments.
-# W1202 - logging-format-interpolation - Behavior barring fstrings in logging https://github.com/PyCQA/pylint/issues/2395.
 # bad-continuation: disagrees with black formatter
 # missing-function-dosctring: docstyle handles
 disable = E0401, E1136, W0201, W0212, W0235, W0511, bad-continuation

--- a/deepblink/__init__.py
+++ b/deepblink/__init__.py
@@ -21,6 +21,7 @@ from . import augment
 from . import cli
 from . import data
 from . import datasets
+from . import inference
 from . import io
 from . import losses
 from . import metrics

--- a/deepblink/__main__.py
+++ b/deepblink/__main__.py
@@ -1,13 +1,5 @@
-"""Entrypoint module, in case you use `python -mdeepblink`.
+"""Entrypoint module, in case you use `python -m deepblink`."""
 
-Read the docs in the usage section or for the `cli` module for information.
-
-Why does this file exist, and why __main__? For more info, read:
-
-- https://www.python.org/dev/peps/pep-0338/
-- https://docs.python.org/2/using/cmdline.html#cmdoption-m
-- https://docs.python.org/3/using/cmdline.html#cmdoption-m
-"""
 from .cli import main
 
 if __name__ == "__main__":

--- a/deepblink/cli.py
+++ b/deepblink/cli.py
@@ -28,9 +28,7 @@ Why does this file exist, and why not put this in __main__?
       ``deepblink.__main__`` in ``sys.modules``.
     - Therefore, to avoid double excecution of the code, this split-up way is safer.
 """
-from typing import List
 import argparse
-import glob
 import os
 import textwrap
 
@@ -44,6 +42,7 @@ from .data import normalize_image
 from .io import basename
 from .io import load_image
 from .io import load_model
+from .io import grab_files
 
 # Removes tensorflow's information on CPU / GPU availablity.
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
@@ -137,28 +136,6 @@ def _parse_args():
     return args
 
 
-def _grab_files(path: str, extensions: List[str]) -> List[str]:
-    """Grab all files in directory with listed extensions.
-
-    Args:
-        path: Path to files to be grabbed. Without trailing "/".
-        extensions: List of all file extensions. Without leading ".".
-
-    Returns:
-        Sorted list of all corresponding files.
-
-    Raises:
-        OSError: Path not existing.
-    """
-    if not os.path.exists(path):
-        raise OSError(f"Path must exist. '{path}' does not.")
-
-    files = []
-    for ext in extensions:
-        files.extend(glob.glob(f"{path}/*.{ext}"))
-    return sorted(files)
-
-
 def _predict(image: np.ndarray, model: tf.keras.models.Model) -> np.ndarray:
     """Returns a binary or categorical model based prediction of an image.
 
@@ -241,7 +218,7 @@ def main():
     # File listing
     inputs = os.path.abspath(args.INPUT)
     if os.path.isdir(inputs):
-        files = _grab_files(inputs, EXTENSIONS)
+        files = grab_files(inputs, EXTENSIONS)
         inpath = inputs
     elif os.path.isfile(inputs):
         files = [inputs]

--- a/deepblink/cli.py
+++ b/deepblink/cli.py
@@ -21,6 +21,7 @@ Optional Arguments:
     -v, --verbose   set program output to verbose [default: quiet]
     -V, --version   show version program's version number and exit
 """
+from typing import List
 import argparse
 import logging
 import os
@@ -28,6 +29,8 @@ import sys
 import textwrap
 
 import numpy as np
+import skimage.io
+import tensorflow as tf
 
 from .inference import predict
 from .inference import get_intensities
@@ -35,12 +38,6 @@ from .io import basename
 from .io import grab_files
 from .io import load_image
 from .io import load_model
-
-
-# Configure verbose logger
-logging.basicConfig(
-    format="%(asctime)s: %(message)s", stream=sys.stdout, level=logging.INFO
-)
 
 # Removes tensorflow's information on CPU / GPU availablity.
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
@@ -79,56 +76,51 @@ class FolderType:
         return value
 
 
-def _parse_args():
-    """Argument parser."""
-    parser = argparse.ArgumentParser(
-        prog="deepblink",
-        description="deepBlinks command line interface \U0001F469\U0000200D\U0001F4BB for training, inferencing, and evaluation",
-        epilog="We hope you enjoy using deepBlink \U0001F603",
-    )
-    parser.add_argument("-V", "--version", action="version", version="%(prog)s 0.0.6")
-    subparsers = parser.add_subparsers(dest="command")
-
-    # Train parser
-    parser_train = subparsers.add_parser(
+def _parse_args_train(subparsers: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Subparser for training."""
+    parser = subparsers.add_parser(
         "train", help="\U0001F35E train a freshly baked model on a dataset",
     )
-    parser_train.add_argument(
+    parser.add_argument(
         "INPUT",
         type=FileFolderType(),
         help=f"input file/folder location [filetypes: {EXTENSIONS}]",
     )
+    return subparsers
 
-    # Check parser
-    parser_check = subparsers.add_parser(
+
+def _parse_args_check(subparsers: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Subparser for checking."""
+    parser = subparsers.add_parser(
         "check", help="\U0001F537 \U0001F535 determine your input images' shape"
     )
-    parser_check.add_argument(
-        "INPUT",
-        type=FileFolderType(),
-        help=f"input file/folder location [filetypes: {EXTENSIONS}]",
+    parser.add_argument(
+        "INPUT", type=str, help=f"input image location [filetypes: {EXTENSIONS}]",
     )
+    return subparsers
 
-    # Predict parser
-    parser_predict = subparsers.add_parser(
+
+def _parse_args_predict(subparsers: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Subparser for prediction."""
+    parser = subparsers.add_parser(
         "predict",
         help="\U0001F914 inference / prediction of data with a pre-trained model",
     )
-    parser_predict.add_argument(
+    parser.add_argument(
         "MODEL", type=argparse.FileType("r"), help="model .h5 file location"
     )
-    parser_predict.add_argument(
+    parser.add_argument(
         "INPUT",
         type=FileFolderType(),
         help=f"input file/folder location [filetypes: {EXTENSIONS}]",
     )
-    parser_predict.add_argument(
+    parser.add_argument(
         "-o",
         "--output",
         type=FolderType(),
         help="output file/folder location [default: input location]",
     )
-    parser_predict.add_argument(
+    parser.add_argument(
         "-t",
         "--type",
         type=str,
@@ -136,7 +128,7 @@ def _parse_args():
         default="csv",
         help="output file type [options: csv, txt] [default: csv]",
     )
-    parser_predict.add_argument(
+    parser.add_argument(
         "-r",
         "--radius",
         type=int,
@@ -221,8 +213,10 @@ class HandlePredict:
         self.extensions = EXTENSIONS
         self.abs_input = os.path.abspath(arg_input)
 
+        self.logger.log(20, "\U0001F914 starting prediction submodule")
+
     @property
-    def path_input(self):
+    def path_input(self) -> str:
         """Return absolute input path (dependent on file/folder input)."""
         if os.path.isdir(self.abs_input):
             path_input = self.abs_input
@@ -231,7 +225,7 @@ class HandlePredict:
         return path_input
 
     @property
-    def file_list(self):
+    def file_list(self) -> List[str]:
         """Return a list with all files to be processed."""
         if os.path.isdir(self.abs_input):
             file_list = grab_files(self.abs_input, self.extensions)
@@ -244,7 +238,7 @@ class HandlePredict:
         return file_list
 
     @property
-    def path_output(self):
+    def path_output(self) -> str:
         """Return the absolute output path (dependent if given)."""
         if os.path.exists(str(self.raw_output)):
             outpath = os.path.abspath(self.raw_output)
@@ -252,7 +246,7 @@ class HandlePredict:
             outpath = self.path_input
         return outpath
 
-    def save_output(self, fname_in, coord_list):
+    def save_output(self, fname_in: str, coord_list: np.ndarray) -> None:
         """Save coordinate list to file with appropriate header."""
         is_radius = self.radius is not None
         if self.type == "txt":
@@ -272,7 +266,7 @@ class HandlePredict:
             comments="",
         )
 
-    def predict_single(self, fname_in, model):
+    def predict_single(self, fname_in: str, model: tf.keras.models.Model) -> None:
         """Predict and save a single image."""
         image = load_image(fname_in)
         coord_list = predict(image, model)
@@ -281,23 +275,42 @@ class HandlePredict:
             coord_list = get_intensities(image, coord_list, self.radius)
 
         self.save_output(fname_in, coord_list)
-        if self.verbose:
-            self.logger.log(20, f"\U0001F3C3 file {fname_in} prediction complete.")
+        self.logger.log(20, f"\U0001F3C3 prediction of file {fname_in} complete")
 
     def run(self):
         """Run prediction for all given images."""
         model = load_model(
             os.path.abspath(self.fname_model)
         )  # noqa: assignment-from-no-return
-        if self.verbose:
-            self.logger.log(20, "\U0001F9E0 model imported.")
-            self.logger.log(20, f"\U0001F4C2 {len(self.file_list)} file(s) found.")
-            self.logger.log(
-                20, f"\U0001F5C4 output will be saved to {self.path_output}."
-            )
+        self.logger.log(20, "\U0001F9E0 model imported")
+        self.logger.log(20, f"\U0001F4C2 {len(self.file_list)} file(s) found")
+        self.logger.log(
+            20, f"\U0001F5C4{' '} output will be saved to {self.path_output}"
+        )
 
         for fname_in in self.file_list:
             self.predict_single(fname_in, model)
 
-        if self.verbose:
-            self.logger.log(20, "\U0001F3C1\U0001F3C3 all predictions are complete.")
+        self.logger.log(20, "\U0001F3C1\U0001F3C3 all predictions are complete")
+
+
+def main():
+    """Entrypoint for the CLI."""
+    args = _parse_args()
+    logger = _configure_logger(args.verbose, args.debug)
+
+    if args.command == "check":
+        handler = HandleCheck(arg_input=args.INPUT, logger=logger)
+
+    if args.command == "predict":
+        handler = HandlePredict(
+            arg_model=args.MODEL.name,
+            arg_input=args.INPUT,
+            arg_output=args.output,
+            arg_radius=args.radius,
+            arg_type=args.type,
+            arg_verbose=args.verbose,
+            logger=logger,
+        )
+
+    handler.run()

--- a/deepblink/cli.py
+++ b/deepblink/cli.py
@@ -33,16 +33,13 @@ import os
 import textwrap
 
 import numpy as np
-import skimage.morphology
-import tensorflow as tf
 
-from .data import get_coordinate_list
-from .data import next_power
-from .data import normalize_image
+from .inference import predict
+from .inference import get_intensities
 from .io import basename
+from .io import grab_files
 from .io import load_image
 from .io import load_model
-from .io import grab_files
 
 # Removes tensorflow's information on CPU / GPU availablity.
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
@@ -136,75 +133,6 @@ def _parse_args():
     return args
 
 
-def _predict(image: np.ndarray, model: tf.keras.models.Model) -> np.ndarray:
-    """Returns a binary or categorical model based prediction of an image.
-
-    Args:
-        image: Image to be predicted.
-        model: Model used to predict the image.
-
-    Returns:
-        List of coordinates [r, c].
-    """
-    # Normalisation and padding
-    image = normalize_image(image)
-    pad_bottom = next_power(image.shape[0], 2) - image.shape[0]
-    pad_right = next_power(image.shape[1], 2) - image.shape[1]
-    image_pad = np.pad(image, ((0, pad_bottom), (0, pad_right)), "reflect")
-
-    # Predict on image
-    pred = model.predict(image_pad[None, ..., None]).squeeze()
-    coords = get_coordinate_list(pred, image_pad.shape[0])
-
-    # Remove spots in padded part of image
-    coords = np.array([coords[..., 0], coords[..., 1]])
-    coords = np.delete(
-        coords,
-        np.where((coords[0] > image.shape[0]) | (coords[1] > image.shape[1])),
-        axis=1,
-    )
-
-    return coords.T  # Transposition to save as rows
-
-
-def get_intensities(
-    image: np.ndarray, coordinate_list: np.ndarray, radius: int
-) -> np.ndarray:
-    """Finds integrated intensities in a radius around each coordinate.
-
-    Args:
-        image: Input image with pixel values.
-        coordinate_list: List of r, c coordinates in shape (n, 2).
-        radius: Radius of kernel to determine intensities.
-
-    Returns:
-        Array with all integrated intensities.
-    """
-    kernel = skimage.morphology.disk(radius)
-
-    for r, c in coordinate_list:
-        if not all([isinstance(i, float) for i in [r, c]]):
-            print(r, c)
-
-    intensities = np.zeros((len(coordinate_list), 1))
-    for idx, (r, c) in enumerate(np.round(coordinate_list).astype(int)):
-        # Selection with indexes will be truncated to the max index possible automatically
-        area = (
-            image[
-                max(r - radius, 0) : r + radius + 1,
-                max(c - radius, 0) : c + radius + 1,
-            ]
-            * kernel[
-                max(radius - r, 0) : radius + image.shape[0] - r,
-                max(radius - c, 0) : radius + image.shape[1] - c,
-            ]
-        )
-        intensities[idx] = np.sum(area)
-
-    output = np.append(coordinate_list, intensities, axis=1)
-    return output
-
-
 def main():
     """Entrypoint for the CLI."""
     args = _parse_args()
@@ -229,7 +157,7 @@ def main():
         print(f"{len(files)} file(s) found.")
 
     # Output path definition
-    if args.output is not None and os.path.exists(args.output):
+    if os.path.exists(str(args.output)):
         outpath = os.path.abspath(args.output)
     else:
         outpath = inpath
@@ -246,7 +174,7 @@ def main():
         image = load_image(file)
 
         # Prediction
-        coord = _predict(image, model)
+        coord = predict(image, model)
 
         # Optional intensity calculation
         if args.radius is not None:

--- a/deepblink/cli.py
+++ b/deepblink/cli.py
@@ -43,10 +43,7 @@ from .data import next_power
 from .data import normalize_image
 from .io import basename
 from .io import load_image
-from .losses import combined_bce_rmse
-from .losses import combined_f1_rmse
-from .losses import f1_score
-from .losses import rmse
+from .io import load_model
 
 # Removes tensorflow's information on CPU / GPU availablity.
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
@@ -237,15 +234,7 @@ def main():
 
     # Model import
     fname_model = os.path.abspath(args.MODEL.name)
-    model = tf.keras.models.load_model(
-        fname_model,
-        custom_objects={
-            "f1_score": f1_score,
-            "rmse": rmse,
-            "combined_bce_rmse": combined_bce_rmse,
-            "combined_f1_rmse": combined_f1_rmse,
-        },
-    )
+    model = load_model(fname_model)  # noqa: assignment-from-no-return
     if args.verbose:
         print("Model imported.")
 

--- a/deepblink/cli/__init__.py
+++ b/deepblink/cli/__init__.py
@@ -1,0 +1,18 @@
+"""Module that contains the command line app.
+
+The CLI is modular containing four distinct submodules which will be
+discussed in more detail below:
+----------
+1. Training
+----------
+2. Checking
+----------
+3. Prediction
+Used for inferencing of new data with pretrained models.
+Because the model is loaded into memory for every run, it is faster to
+run multiple images at once by passing a directory as input.
+----------
+4. Evaluation
+"""
+
+from ._main import main

--- a/deepblink/cli/_handler.py
+++ b/deepblink/cli/_handler.py
@@ -1,31 +1,8 @@
-"""Module that contains the command line app.
+"""Event handlers for deepblinks CLI."""
 
-Used for inferencing of new data with pretrained models.
-Because the model is loaded into memory for every run, it is faster to
-run multiple images at once by passing a directory as input.
-
-Usage:
-    ``$ deepblink [-h] [-o OUTPUT] [-t {csv,txt}] [-r RADIUS] [-v] [-V] MODEL INPUT``
-    ``$ deepblink --help``
-
-Positional Arguments:
-    MODEL           model .h5 file location
-    INPUT           input file/folder location
-
-Optional Arguments:
-    -h, --help      show this help screen
-
-    -o, --output    output file/folder location [default: input location]
-    -t, --type      output file type [options: csv, txt] [default: csv]
-    -r, --radius    if given, calculate the integrated intensity in the given radius around each coordinate
-    -v, --verbose   set program output to verbose [default: quiet]
-    -V, --version   show version program's version number and exit
-"""
 from typing import List
-import argparse
 import logging
 import os
-import sys
 import textwrap
 import yaml
 
@@ -33,196 +10,16 @@ import numpy as np
 import skimage.io
 import tensorflow as tf
 
-from .inference import get_intensities
-from .inference import predict
-from .io import basename
-from .io import grab_files
-from .io import load_image
-from .io import load_model
-from .training import run_experiment
-
-# Removes tensorflow's information on CPU / GPU availablity.
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
+from ..inference import get_intensities
+from ..inference import predict
+from ..io import basename
+from ..io import grab_files
+from ..io import load_image
+from ..io import load_model
+from ..training import run_experiment
 
 # List of currently supported image file extensions.
 EXTENSIONS = ["tif", "jpeg", "jpg", "png"]
-
-
-class FileFolderType:
-    """Custom type supporting folders or files."""
-
-    def __init__(self):
-        pass
-
-    def __call__(self, value):  # noqa: D102
-        """Python type internal function called by argparse to check input."""
-        if not any((os.path.isdir(value), os.path.isfile(value))):
-            raise argparse.ArgumentTypeError(
-                f"Input value must be file or folder. '{value}' is not."
-            )
-        return value
-
-
-class FolderType:
-    """Custom type supporting folders."""
-
-    def __init__(self):
-        pass
-
-    def __call__(self, value):  # noqa: D102
-        """Python type internal function called by argparse to check input."""
-        if not os.path.isdir(value):
-            raise argparse.ArgumentTypeError(
-                f"Input value must be folder and must exist. '{value}' is not."
-            )
-        return value
-
-
-def _parse_args_train(
-    subparsers: argparse._SubParsersAction,
-) -> argparse._SubParsersAction:
-    """Subparser for training."""
-    parser = subparsers.add_parser(
-        "train", help="\U0001F35E train a freshly baked model on a dataset",
-    )
-    parser.add_argument(
-        "-c",
-        "--config",
-        type=str,
-        required=True,
-        help="path to the experimental config.yaml file. Check the GitHub repository for an example",
-    )
-    parser.add_argument(
-        "-g",
-        "--gpu",
-        type=int,
-        default=None,
-        help="index of GPU to be used [default: None]",
-    )
-    return subparsers
-
-
-def _parse_args_check(
-    subparsers: argparse._SubParsersAction,
-) -> argparse._SubParsersAction:
-    """Subparser for checking."""
-    parser = subparsers.add_parser(
-        "check", help="\U0001F537 \U0001F535 determine your input images' shape"
-    )
-    parser.add_argument(
-        "INPUT", type=str, help=f"input image location [filetypes: {EXTENSIONS}]",
-    )
-    return subparsers
-
-
-def _parse_args_predict(
-    subparsers: argparse._SubParsersAction,
-) -> argparse._SubParsersAction:
-    """Subparser for prediction."""
-    parser = subparsers.add_parser(
-        "predict",
-        help="\U0001F914 inference / prediction of data with a pre-trained model",
-    )
-    parser.add_argument(
-        "MODEL", type=argparse.FileType("r"), help="model .h5 file location"
-    )
-    parser.add_argument(
-        "INPUT",
-        type=FileFolderType(),
-        help=f"input file/folder location [filetypes: {EXTENSIONS}]",
-    )
-    parser.add_argument(
-        "-o",
-        "--output",
-        type=FolderType(),
-        help="output file/folder location [default: input location]",
-    )
-    parser.add_argument(
-        "-t",
-        "--type",
-        type=str,
-        choices=["csv", "txt"],
-        default="csv",
-        help="output file type [options: csv, txt] [default: csv]",
-    )
-    parser.add_argument(
-        "-r",
-        "--radius",
-        type=int,
-        default=None,
-        help=textwrap.dedent(
-            """if given, calculate the integrated intensity
-        in the given radius around each coordinate. set radius to zero if only the
-        central pixels intensity should be calculated."""
-        ),
-    )
-    return subparsers
-
-
-def _parse_args_eval(
-    subparsers: argparse._SubParsersAction,
-) -> argparse._SubParsersAction:
-    """Subparser for evaluation."""
-    parser = subparsers.add_parser(
-        "eval", help="\U0001F3AD measure a models performance on a dataset"
-    )
-    parser.add_argument(
-        "INPUT",
-        type=FileFolderType(),
-        help=f"input file/folder location [filetypes: {EXTENSIONS}]",
-    )
-    return subparsers
-
-
-def _parse_args():
-    """Argument parser."""
-    parser = argparse.ArgumentParser(
-        prog="deepblink",
-        description=textwrap.dedent(
-            """deepBlinks command line interface \U0001F469\U0000200D\U0001F4BB
-        for training, inferencing, and evaluation"""
-        ),
-        epilog="We hope you enjoy using deepBlink \U0001F603",
-    )
-    parser.add_argument("-V", "--version", action="version", version="%(prog)s 0.0.6")
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="set program output to verbose [default: quiet]",
-    )
-    parser.add_argument("--debug", action="store_true", help=argparse.SUPPRESS)
-
-    subparsers = parser.add_subparsers(dest="command")
-    subparsers = _parse_args_train(subparsers)
-    subparsers = _parse_args_check(subparsers)
-    subparsers = _parse_args_predict(subparsers)
-    subparsers = _parse_args_eval(subparsers)
-
-    args = parser.parse_args()
-    return args
-
-
-def _configure_logger(verbose: bool, debug: bool):
-    """Return verbose logger with three levels.
-
-    * Verbose false and debug false - no verbose logging.
-    * Verbose true and debug false - only info level loginfo for standard users.
-    * Debug true - debug mode for developers.
-    """
-    if debug:
-        level = logging.DEBUG
-    else:
-        if verbose:
-            level = logging.INFO
-        else:
-            level = logging.CRITICAL
-
-    logging.basicConfig(
-        format="%(asctime)s: %(message)s", stream=sys.stdout, level=level
-    )
-    logger = logging.getLogger("Verbose output logger")
-    return logger
 
 
 class HandleTrain:
@@ -456,28 +253,3 @@ class HandlePredict:
             self.predict_single(fname_in, model)
 
         self.logger.log(20, "\U0001F3C1\U0001F3C3 all predictions are complete")
-
-
-def main():
-    """Entrypoint for the CLI."""
-    args = _parse_args()
-    logger = _configure_logger(args.verbose, args.debug)
-
-    if args.command == "train":
-        handler = HandleTrain(arg_config=args.config, arg_gpu=args.gpu, logger=logger)
-
-    if args.command == "check":
-        handler = HandleCheck(arg_input=args.INPUT, logger=logger)
-
-    if args.command == "predict":
-        handler = HandlePredict(
-            arg_model=args.MODEL.name,
-            arg_input=args.INPUT,
-            arg_output=args.output,
-            arg_radius=args.radius,
-            arg_type=args.type,
-            arg_verbose=args.verbose,
-            logger=logger,
-        )
-
-    handler.run()

--- a/deepblink/cli/_logger.py
+++ b/deepblink/cli/_logger.py
@@ -1,0 +1,26 @@
+"""Logging related functions for deepblinks CLI."""
+
+import logging
+import sys
+
+
+def _configure_logger(verbose: bool, debug: bool):
+    """Return verbose logger with three levels.
+
+    * Verbose false and debug false - no verbose logging.
+    * Verbose true and debug false - only info level loginfo for standard users.
+    * Debug true - debug mode for developers.
+    """
+    if debug:
+        level = logging.DEBUG
+    else:
+        if verbose:
+            level = logging.INFO
+        else:
+            level = logging.CRITICAL
+
+    logging.basicConfig(
+        format="%(asctime)s: %(message)s", stream=sys.stdout, level=level
+    )
+    logger = logging.getLogger("Verbose output logger")
+    return logger

--- a/deepblink/cli/_main.py
+++ b/deepblink/cli/_main.py
@@ -1,0 +1,32 @@
+"""Main / entrypoint function for deepblinks CLI."""
+
+from ._handler import HandleCheck
+from ._handler import HandlePredict
+from ._handler import HandleTrain
+from ._logger import _configure_logger
+from ._parser import _parse_args
+
+
+def main():
+    """Entrypoint for the CLI."""
+    args = _parse_args()
+    logger = _configure_logger(args.verbose, args.debug)
+
+    if args.command == "train":
+        handler = HandleTrain(arg_config=args.config, arg_gpu=args.gpu, logger=logger)
+
+    if args.command == "check":
+        handler = HandleCheck(arg_input=args.INPUT, logger=logger)
+
+    if args.command == "predict":
+        handler = HandlePredict(
+            arg_model=args.MODEL.name,
+            arg_input=args.INPUT,
+            arg_output=args.output,
+            arg_radius=args.radius,
+            arg_type=args.type,
+            arg_verbose=args.verbose,
+            logger=logger,
+        )
+
+    handler.run()

--- a/deepblink/cli/_parser.py
+++ b/deepblink/cli/_parser.py
@@ -1,0 +1,132 @@
+"""Argument parsing for deepblinks CLI."""
+
+import argparse
+import textwrap
+
+from ._handler import EXTENSIONS
+from ._type import FileFolderType
+from ._type import FolderType
+
+
+def _parse_args_train(
+    subparsers: argparse._SubParsersAction,
+) -> argparse._SubParsersAction:
+    """Subparser for training."""
+    parser = subparsers.add_parser(
+        "train", help="\U0001F35E train a freshly baked model on a dataset",
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        required=True,
+        help="path to the experimental config.yaml file. Check the GitHub repository for an example",
+    )
+    parser.add_argument(
+        "-g",
+        "--gpu",
+        type=int,
+        default=None,
+        help="index of GPU to be used [default: None]",
+    )
+    return subparsers
+
+
+def _parse_args_check(
+    subparsers: argparse._SubParsersAction,
+) -> argparse._SubParsersAction:
+    """Subparser for checking."""
+    parser = subparsers.add_parser(
+        "check", help="\U0001F537 \U0001F535 determine your input images' shape"
+    )
+    parser.add_argument(
+        "INPUT", type=str, help=f"input image location [filetypes: {EXTENSIONS}]",
+    )
+    return subparsers
+
+
+def _parse_args_predict(
+    subparsers: argparse._SubParsersAction,
+) -> argparse._SubParsersAction:
+    """Subparser for prediction."""
+    parser = subparsers.add_parser(
+        "predict",
+        help="\U0001F914 inference / prediction of data with a pre-trained model",
+    )
+    parser.add_argument(
+        "MODEL", type=argparse.FileType("r"), help="model .h5 file location"
+    )
+    parser.add_argument(
+        "INPUT",
+        type=FileFolderType(),
+        help=f"input file/folder location [filetypes: {EXTENSIONS}]",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=FolderType(),
+        help="output file/folder location [default: input location]",
+    )
+    parser.add_argument(
+        "-t",
+        "--type",
+        type=str,
+        choices=["csv", "txt"],
+        default="csv",
+        help="output file type [options: csv, txt] [default: csv]",
+    )
+    parser.add_argument(
+        "-r",
+        "--radius",
+        type=int,
+        default=None,
+        help=textwrap.dedent(
+            """if given, calculate the integrated intensity
+        in the given radius around each coordinate. set radius to zero if only the
+        central pixels intensity should be calculated."""
+        ),
+    )
+    return subparsers
+
+
+def _parse_args_eval(
+    subparsers: argparse._SubParsersAction,
+) -> argparse._SubParsersAction:
+    """Subparser for evaluation."""
+    parser = subparsers.add_parser(
+        "eval", help="\U0001F3AD measure a models performance on a dataset"
+    )
+    parser.add_argument(
+        "INPUT",
+        type=FileFolderType(),
+        help=f"input file/folder location [filetypes: {EXTENSIONS}]",
+    )
+    return subparsers
+
+
+def _parse_args():
+    """Argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="deepblink",
+        description=textwrap.dedent(
+            """deepBlink's CLI \U0001F469\U0000200D\U0001F4BB for training, inferencing, and evaluation"""
+        ),
+        epilog="We hope you enjoy using deepBlink \U0001F603",
+    )
+    parser.add_argument("-V", "--version", action="version", version="%(prog)s 0.0.6")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="set program output to verbose [default: quiet]",
+    )
+    parser.add_argument("--debug", action="store_true", help=argparse.SUPPRESS)
+
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers = _parse_args_train(subparsers)
+    subparsers = _parse_args_check(subparsers)
+    subparsers = _parse_args_predict(subparsers)
+    subparsers = _parse_args_eval(subparsers)
+
+    args = parser.parse_args()
+    return args

--- a/deepblink/cli/_type.py
+++ b/deepblink/cli/_type.py
@@ -1,0 +1,34 @@
+"""Custom argparse types / classes."""
+
+import os
+import argparse
+
+
+class FileFolderType:
+    """Custom type supporting folders or files."""
+
+    def __init__(self):
+        pass
+
+    def __call__(self, value):  # noqa: D102
+        """Python type internal function called by argparse to check input."""
+        if not any((os.path.isdir(value), os.path.isfile(value))):
+            raise argparse.ArgumentTypeError(
+                f"Input value must be file or folder. '{value}' is not."
+            )
+        return value
+
+
+class FolderType:
+    """Custom type supporting folders."""
+
+    def __init__(self):
+        pass
+
+    def __call__(self, value):  # noqa: D102
+        """Python type internal function called by argparse to check input."""
+        if not os.path.isdir(value):
+            raise argparse.ArgumentTypeError(
+                f"Input value must be folder and must exist. '{value}' is not."
+            )
+        return value

--- a/deepblink/data.py
+++ b/deepblink/data.py
@@ -100,7 +100,7 @@ def get_coordinate_list(matrix: np.ndarray, image_size: int = 512) -> np.ndarray
     if not matrix.shape[0] == matrix.shape[1] and not matrix.shape[0] >= 1:
         raise ValueError("Matrix must have equal length >= 1 of r, c.")
 
-    matrix_size = matrix.shape[0]
+    matrix_size = max(matrix.shape)  # Handles non-square images
     cell_size = image_size // matrix_size
     coords_r = []
     coords_c = []

--- a/deepblink/inference.py
+++ b/deepblink/inference.py
@@ -1,0 +1,78 @@
+"""Model prediction / inference functions."""
+
+import numpy as np
+import skimage.morphology
+import tensorflow as tf
+
+from .data import get_coordinate_list
+from .data import next_power
+from .data import normalize_image
+
+
+def predict(image: np.ndarray, model: tf.keras.models.Model) -> np.ndarray:
+    """Returns a binary or categorical model based prediction of an image.
+
+    Args:
+        image: Image to be predicted.
+        model: Model used to predict the image.
+
+    Returns:
+        List of coordinates [r, c].
+    """
+    # Normalisation and padding
+    image = normalize_image(image)
+    pad_bottom = next_power(image.shape[0], 2) - image.shape[0]
+    pad_right = next_power(image.shape[1], 2) - image.shape[1]
+    image_pad = np.pad(image, ((0, pad_bottom), (0, pad_right)), "reflect")
+
+    # Predict on image
+    pred = model.predict(image_pad[None, ..., None]).squeeze()
+    coords = get_coordinate_list(pred, image_pad.shape[0])
+
+    # Remove spots in padded part of image
+    coords = np.array([coords[..., 0], coords[..., 1]])
+    coords = np.delete(
+        coords,
+        np.where((coords[0] > image.shape[0]) | (coords[1] > image.shape[1])),
+        axis=1,
+    )
+
+    return coords.T  # Transposition to save as rows
+
+
+def get_intensities(
+    image: np.ndarray, coordinate_list: np.ndarray, radius: int
+) -> np.ndarray:
+    """Finds integrated intensities in a radius around each coordinate.
+
+    Args:
+        image: Input image with pixel values.
+        coordinate_list: List of r, c coordinates in shape (n, 2).
+        radius: Radius of kernel to determine intensities.
+
+    Returns:
+        Array with all integrated intensities.
+    """
+    kernel = skimage.morphology.disk(radius)
+
+    for r, c in coordinate_list:
+        if not all([isinstance(i, float) for i in [r, c]]):
+            print(r, c)
+
+    intensities = np.zeros((len(coordinate_list), 1))
+    for idx, (r, c) in enumerate(np.round(coordinate_list).astype(int)):
+        # Selection with indexes will be truncated to the max index possible automatically
+        area = (
+            image[
+                max(r - radius, 0) : r + radius + 1,
+                max(c - radius, 0) : c + radius + 1,
+            ]
+            * kernel[
+                max(radius - r, 0) : radius + image.shape[0] - r,
+                max(radius - c, 0) : radius + image.shape[1] - c,
+            ]
+        )
+        intensities[idx] = np.sum(area)
+
+    output = np.append(coordinate_list, intensities, axis=1)
+    return output

--- a/deepblink/io.py
+++ b/deepblink/io.py
@@ -2,6 +2,7 @@
 
 from typing import Any, List
 import os
+import glob
 import warnings
 
 import numpy as np
@@ -94,3 +95,25 @@ def load_model(fname: str) -> tf.keras.models.Model:
         return model
     except ValueError as error:
         raise ImportError(f"Model '{fname}' could not be imported.") from error
+
+
+def grab_files(path: str, extensions: List[str]) -> List[str]:
+    """Grab all files in directory with listed extensions.
+
+    Args:
+        path: Path to files to be grabbed. Without trailing "/".
+        extensions: List of all file extensions. Without leading ".".
+
+    Returns:
+        Sorted list of all corresponding files.
+
+    Raises:
+        OSError: Path not existing.
+    """
+    if not os.path.exists(path):
+        raise OSError(f"Path must exist. '{path}' does not.")
+
+    files = []
+    for ext in extensions:
+        files.extend(glob.glob(f"{path}/*.{ext}"))
+    return sorted(files)

--- a/deepblink/io.py
+++ b/deepblink/io.py
@@ -79,7 +79,7 @@ def load_model(fname: str) -> tf.keras.models.Model:
     """Import a deepBlink model from file."""
     if not os.path.isfile(fname):
         raise ValueError(f"File must exist - '{fname}' does not.")
-    if os.path.splitext(fname)[-1] != "h5":
+    if os.path.splitext(fname)[-1] != ".h5":
         raise ValueError(f"File must be of type h5 - '{fname}' does not.")
 
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,34 +1,16 @@
 """Unittests for the deepblink.cli module."""
 # pylint: disable=missing-function-docstring,redefined-outer-name
 
-from pathlib import Path
-import os
-import tempfile
-
 import numpy as np
 import pytest
 import tensorflow as tf
 
-from deepblink.cli import _grab_files
 from deepblink.cli import _predict
 from deepblink.cli import get_intensities
 from deepblink.losses import combined_bce_rmse
 from deepblink.losses import combined_f1_rmse
 from deepblink.losses import f1_score
 from deepblink.losses import rmse
-
-
-def test_grab_files():
-    """Test function that grabs files in a directory given the extensions."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        fnames = ["test.txt", "text.csv", "test.h5", "csv.test"]
-        for fname in fnames:
-            Path(os.path.join(temp_dir, fname)).touch()
-
-        ext = ["txt", "csv"]
-        output = _grab_files(temp_dir, ext)
-        expected = [os.path.join(temp_dir, f) for f in ["test.txt", "text.csv"]]
-        assert output == expected
 
 
 def test_predict():

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,12 +1,12 @@
-"""Unittests for the deepblink.cli module."""
+"""Unittests for the deepblink.inference module."""
 # pylint: disable=missing-function-docstring,redefined-outer-name
 
 import numpy as np
 import pytest
 import tensorflow as tf
 
-from deepblink.cli import _predict
-from deepblink.cli import get_intensities
+from deepblink.inference import get_intensities
+from deepblink.inference import predict
 from deepblink.losses import combined_bce_rmse
 from deepblink.losses import combined_f1_rmse
 from deepblink.losses import f1_score
@@ -30,7 +30,7 @@ def test_predict():
 
     for size in [249, 512, 876]:
         image = np.random.rand(size, size)
-        pred = _predict(image, model)
+        pred = predict(image, model)
         assert isinstance(pred, np.ndarray)
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,7 @@
 """Unittests for the deepblink.io module."""
 # pylint: disable=missing-function-docstring
 
+from pathlib import Path
 import os
 import tempfile
 
@@ -13,6 +14,7 @@ import pytest
 
 from deepblink.io import basename
 from deepblink.io import load_npz
+from deepblink.io import grab_files
 from deepblink.io import remove_zeros
 
 
@@ -57,3 +59,16 @@ def test_load_npz():
         # Load only test dataset
         data = load_npz(fname, test_only=True)
         assert len(data) == 2
+
+
+def test_grab_files():
+    """Test function that grabs files in a directory given the extensions."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        fnames = ["test.txt", "text.csv", "test.h5", "csv.test"]
+        for fname in fnames:
+            Path(os.path.join(temp_dir, fname)).touch()
+
+        ext = ["txt", "csv"]
+        output = grab_files(temp_dir, ext)
+        expected = [os.path.join(temp_dir, f) for f in ["test.txt", "text.csv"]]
+        assert output == expected


### PR DESCRIPTION
## Proposed changes

This change is the first of at least three to revamp the CLI. The biggest changes are:
* Separation of one `cli.py` file into its own directory and the io functions into `io.py` and prediction functions into `inference.py`.
* Multiple submodules:
  - Train: training functionality currently found in `bin/`
  - Check: printing of image shape (FIJI doesn't provide any functionality) with example shape prediction
  - Prediction: prediction of a single image! multi-shaped images using the shape input from check will be added in the next PR.
  - Eval: currently only boilerplate and not functional!
* Fix of non-square shaped images for `get_coordinate_list`.

## Types of changes

 - [x] Bugfix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation content update
 - [ ] Other (please describe):

## Checklist

Put an x in the boxes that apply. You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask. We're here to help!
This is simply a reminder of what we are going to look for before merging your code so nothing breaks.

 - [x] I have read the [contributing guidelines](https://deepblink.readthedocs.io/en/latest/contributing.html)
 - [x] Lint and unit tests pass locally with my changes (`tox`)
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] I have added necessary documentation (if appropriate)
 - [x] Any dependent changes have been merged and published in downstream modules
 - [x] My commit messages format follow the project [git commit message format](https://github.com/slashsbin/styleguide-git-commit-message#commit-message-format)*
 - [ ] First time only - I have added myself / the copyright holder to the authors.rst file

💔 Thank you!

\* Please note we only use the following (same semantic meaning as described) 🎨📰📝🐎📚🐛🚑🔥🚜🔨☔💚💎✨⬆️⬇️
